### PR TITLE
Add libcurl to packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.tar.gz
+*.tar.xz
 *.pkg.tar.zst

--- a/libcurl/PKGBUILD
+++ b/libcurl/PKGBUILD
@@ -1,0 +1,49 @@
+pkgname=ps4-openorbis-libcurl
+pkgver=8.4.0
+pkgrel=1
+pkgdesc='An URL retrieval utility and library'
+arch=('any')
+url='https://curl.se/'
+license=('curl')
+source=("https://curl.se/download/curl-${pkgver}.tar.xz")
+sha256sums=('16c62a9c4af0f703d28bda6d7bbf37ba47055ad3414d70dec63e2e6336f2a82d')
+options=(!strip !debug libtool staticlibs)
+depends=('ps4-openorbis-zlib')
+makedepends=('ps4-openorbis-pkg-config' 'ps4-openorbis-vars')
+groups=(
+  'pacbrew' 'pacbrew-ps4' 'pacbrew-ps4-portlibs'
+  'ps4-openorbis-portlibs' # for backward compatibility
+)
+
+prepare() {
+  cd curl-$pkgver
+
+  # TODO: fix this (use proper patch)...
+  sed -i 's|#include <osreldate.h>|//#include <osreldate.h>|g' include/curl/curl.h
+}
+
+build() {
+  cd curl-$pkgver
+
+  source /opt/pacbrew/ps4/openorbis/ps4vars.sh
+
+  CFLAGS="${CFLAGS} -DSOL_IP=0"
+  LIBS="${LIBS} -lSceNet"
+
+  autoreconf -fi
+
+  ./configure --prefix="${OPENORBIS}/usr" --host=x86_64-freebsd12 \
+    --disable-shared --enable-static --enable-websockets \
+    --with-mbedtls --disable-manual  
+
+  make -C lib
+}
+
+package() {
+  cd curl-$pkgver
+  source /opt/pacbrew/ps4/openorbis/ps4vars.sh
+
+  make DESTDIR="$pkgdir" -C lib install
+  make DESTDIR="$pkgdir" -C include install
+  make DESTDIR="$pkgdir" install-binSCRIPTS
+}


### PR DESCRIPTION
Upgrades libcurl to version 8.4.0 with WebSockets enabled for Mist++.